### PR TITLE
Add `farewell` helper, tests, and README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Run the `hello.py` script to see a greeting:
 python hello.py
 ```
 
+You can also import the module to use `greet` or `farewell`:
+
+```python
+from hello import greet, farewell
+
+print(greet("Codex"))
+print(farewell("Codex"))
+```
+
 ## Running Tests
 
 Tests use `pytest`. Install it and run:
@@ -18,4 +27,3 @@ Tests use `pytest`. Install it and run:
 pip install pytest
 pytest
 ```
-

--- a/hello.py
+++ b/hello.py
@@ -6,5 +6,10 @@ def greet(name: str = "World") -> str:
     return f"Hello, {name}!"
 
 
+def farewell(name: str = "World") -> str:
+    """Return a farewell for the provided name."""
+    return f"Goodbye, {name}!"
+
+
 if __name__ == "__main__":
     print(greet())

--- a/test_hello.py
+++ b/test_hello.py
@@ -1,4 +1,4 @@
-from hello import greet
+from hello import farewell, greet
 
 
 def test_greet_default():
@@ -7,3 +7,11 @@ def test_greet_default():
 
 def test_greet_custom():
     assert greet("Alice") == "Hello, Alice!"
+
+
+def test_farewell_default():
+    assert farewell() == "Goodbye, World!"
+
+
+def test_farewell_custom():
+    assert farewell("Alice") == "Goodbye, Alice!"


### PR DESCRIPTION
### Motivation
- Provide a matching farewell utility alongside the existing `greet` function and document its usage so the module can be used both as a script and as an importable API.

### Description
- Add a `farewell(name: str = "World") -> str` function to `hello.py` that returns a goodbye message.
- Update `README.md` to show importing and using `greet` and `farewell` with a short example.
- Update `test_hello.py` to import `farewell` and add `test_farewell_default` and `test_farewell_custom` to cover the new behavior.
- Modified files: `hello.py`, `README.md`, and `test_hello.py`.

### Testing
- Ran `pytest -q` and all tests passed with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e01d9da7883218a5a73c4aeb7591b)